### PR TITLE
A rudimentary attempt to scale the size of the chat bubble.

### DIFF
--- a/coding_assistant/__init__.py
+++ b/coding_assistant/__init__.py
@@ -4,7 +4,7 @@ import sys
 _old_hook = sys.excepthook
 
 # I don't want to be sued my MS so I'll use a single 'p'
-clipy = """\\_______________________________/
+clipy = """
  _-_  | /
 /_  \\ |/
 (o)(o)
@@ -14,9 +14,11 @@ clipy = """\\_______________________________/
  ¯--¯"""
 
 
-def assistant_print(type_, value, traceback):
-    _old_hook(type_, value, traceback)
-    print(clipy)
+def assistant_print(type_, value, tb):
+    _old_hook(type_, value, tb)
+    width = len(f"{type_.__qualname__}{f': {value}' if value else ''}")-2
+    print(f"\\{'_'*width}/" + clipy)
+
 
 
 sys.excepthook = assistant_print


### PR DESCRIPTION
Instead of having the bubble stay fixed, I just multiplied the width by the length of the given Exception message.

![image](https://user-images.githubusercontent.com/29679755/140832758-cb2c70f3-7349-4cf9-b127-3d4d649308f1.png)

This script could expand to parser exceptions as well, eg. SyntaxError if it was turned into a pythonrunner wrapper script. Which just took the given file, compiled it and exec'ed it.
`clipy main.py`