### PR TITLE
Cli attempt

### DIFF
--- a/coding_assistant/__init__.py
+++ b/coding_assistant/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 _old_hook = sys.excepthook
 
-# I don't want to be sued my MS so I'll use a single 'p'
+# I don't want to be sued by MS so I'll use a single 'p'
 clipy = """
  _-_  | /
 /_  \\ |/
@@ -14,11 +14,26 @@ clipy = """
  ¯--¯"""
 
 
+def pathname(obj):
+    """Create qualified pathname for objs. eg. module.sub.obj, module.sub.inner.obj"""
+
+    module = obj.__module__
+
+    # TB doesn't include builtin path
+    if module is None or module == "builtins":
+        return obj.__name__
+    return module + '.' + obj.__name__
+
+
 def assistant_print(type_, value, tb):
     _old_hook(type_, value, tb)
-    width = len(f"{type_.__qualname__}{f': {value}' if value else ''}")-2
-    print(f"\\{'_'*width}/" + clipy)
-
+    # Traceback is inconsistent about which path to use, `format_exception_only` displays relative paths,
+    # dropping magic roots, eg. "__main__" but still formatting necessary message information
+    # When the exception hook uses them, it drops absolute paths, eg. "__main__.Super.Sub" becomes "__main__.Sub"
+    message = traceback.format_exception_only(value).pop().strip().split(": ", 1)
+    message[0] = pathname(type_)
+    width = len(": ".join(message)) - 2
+    print(f"\\{'_' * width}/" + clipy, file=sys.stderr)
 
 
 sys.excepthook = assistant_print

--- a/coding_assistant/__init__.py
+++ b/coding_assistant/__init__.py
@@ -1,5 +1,11 @@
 # type: ignore
 import sys
+import traceback
+
+
+class AssistantException(Exception):
+    ...
+
 
 _old_hook = sys.excepthook
 

--- a/coding_assistant/__main__.py
+++ b/coding_assistant/__main__.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+from subprocess import Popen, PIPE
+
+import coding_assistant
+
+
+# Hardcoded values, helps refactoring for multiple assistants down the line
+PATH_IDX = 1
+ARGS_IDX = 2
+ASSISTANT = coding_assistant.clipy
+
+
+def cli():
+    try:
+        path = Path(sys.argv[PATH_IDX]).resolve()
+    except IndexError:
+        raise coding_assistant.AssistantException("Path to file is missing!") from None
+    args = sys.argv[ARGS_IDX:]
+
+    # Path to Python Interpreter
+    python = sys.executable
+    p = Popen([python, path, *args], text=True, stdin=sys.stdin, stdout=sys.stdout, stderr=PIPE)
+    _, err = p.communicate()
+    if err:
+        # Normal encoding of the ASCII art was causing errors, this is Windows-1252, a legacy encoding scheme
+        err = err
+
+        # Break into lines
+        split_assistant = ASSISTANT.splitlines()
+        split_err = err.splitlines()
+
+        # Prevent double assistant by comparing lines that should be equivalent
+        # Skip first line due to funky spacing of decoded characters
+        if split_assistant[1:] != split_err[-len(split_assistant)+1:]:
+            width = len(split_err[-1]) - 2
+            err += f"\\{'_' * width}/" + ASSISTANT
+
+        print(err, file=sys.stderr)
+    return p.returncode
+
+
+if __name__ == '__main__':
+    sys.exit(cli())

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.9',
+    entry_points={'console_scripts': [
+        'assistant = coding_assistant.__main__:cli',
+        ],
+    }
 )


### PR DESCRIPTION
Hi,

I took a crack at making a Cli tool, as I noted in the commit, it's got a pretty significant limitation at the moment. 

> Using `input("prompt")` buffers the output of the prompt until user input has been given. This likely extends to other areas of user interaction as well. This also seemingly varies from terminal to terminal, PyCharms builtin terminal ignores this limitation and functions fine. Windows powershell and cmd both buffer the input, alongside the buffered input, both terminals also pass the prompt of the input to stderr instead of stdout.

I figured I'd let you take a glance and determine if you could spot any other methods of going about it. 

While doing that I noticed that the method of getting the length was wrong in some edge cases. Those should be dealt with however, there is also an issue of CPython injecting content into the traceback after it's been pulled into the lower level environment. The new 3.10 suggestions don't appear in exceptions created by the traceback module at the moment, currently it seems the only way to match the sizing is the capture the output of stderr and parse that, but as always, that's a bit iffy.
![image](https://user-images.githubusercontent.com/29679755/141023109-f822d122-a1cb-4dfe-8a7a-e920c3f1cd30.png)
The traceback module only creates up to `not defined`, everything past that is generated after the exception has been fired off. 


![image](https://user-images.githubusercontent.com/29679755/141022976-b15c002a-6d27-409d-96e0-6befd86dd960.png)
![image](https://user-images.githubusercontent.com/29679755/141022937-fb553b95-1f0a-476a-9ea5-56bf42b63bc9.png)
![image](https://user-images.githubusercontent.com/29679755/141022959-dfd95510-2fcc-4adf-9a0e-3b626476ebfe.png)
